### PR TITLE
Add variant information, in particular to allow attribution to the creators.

### DIFF
--- a/variants/classical/classical.go
+++ b/variants/classical/classical.go
@@ -42,6 +42,10 @@ var ClassicalVariant = common.Variant{
 			return Asset("svg/fleet.svg")
 		},
 	},
+	CreatedBy: "Allan B. Calhamer",
+	Version: "",
+	Description: "The original game of Diplomacy.",
+	Rules: "The first to 18 supply centers is the winner. See the Wikibooks article for how to play: https://en.wikibooks.org/wiki/Diplomacy/Rules",
 }
 func Blank(phase dip.Phase) *state.State {
 	return state.New(start.Graph(), phase, BackupRule)

--- a/variants/common/common.go
+++ b/variants/common/common.go
@@ -42,4 +42,12 @@ type Variant struct {
 	SVGVersion string
 	// SVG representing the variant units.
 	SVGUnits map[dip.UnitType]func() ([]byte, error) `json:"-"`
+	// Who the version was created by (or the empty string if no creator information is known).
+	CreatedBy string
+	// Version of the variant (or the empty string if no version information is known).
+	Version string
+	// A short description summarising the variant.
+	Description string
+	// The rules of the variant (in particular where they differ from classical).
+	Rules string
 }

--- a/variants/fleetrome/fleetrome.go
+++ b/variants/fleetrome/fleetrome.go
@@ -49,4 +49,8 @@ var FleetRomeVariant = common.Variant{
 			return classical.Asset("svg/fleet.svg")
 		},
 	},
+	CreatedBy: "Richard Sharp",
+	Version: "",
+	Description: "Classical Diplomacy, but Italy starts with a fleet in Rome.",
+	Rules: "The first to 18 supply centers is the winner.  Rules are as per classical Diplomacy, but Italy starts with a fleet in Rome rather than an army.",
 }

--- a/variants/franceaustria/franceaustria.go
+++ b/variants/franceaustria/franceaustria.go
@@ -74,4 +74,8 @@ var FranceAustriaVariant = common.Variant{
 			return classical.Asset("svg/fleet.svg")
 		},
 	},
+	CreatedBy: "",
+	Version: "",
+	Description: "A two player variant on the classical map.",
+	Rules: "The first to 18 supply centers is the winner. The rules are as per classical Diplomacy, but with only France and Austria.",
 }

--- a/variants/pure/pure.go
+++ b/variants/pure/pure.go
@@ -40,6 +40,10 @@ var PureVariant = common.Variant{
 			return classical.Asset("svg/army.svg")
 		},
 	},
+	CreatedBy: "Danny Loeb",
+	Version: "vb10",
+	Description: "A very minimal version of classical Diplomacy where each country is a single province.",
+	Rules: "Each of the seven nations has a single supply center, and each is adjacent to all of the others. The first player to own four of these centers is the winner.",
 }
 
 func PureBlank(phase dip.Phase) *state.State {


### PR DESCRIPTION
The clients won't currently use this information, but the description and rules
should be very useful to players unfamiliar with the variants.

The sources I used for attribution were:
Classical: https://en.wikipedia.org/wiki/Diplomacy_(game)
Fleet Rome: http://www.floc.net/dpjudge/?page=about_fleetRome
Pure: http://www.variantbank.org/results/rules/p/pure.htm

I couldn't find any creator information for France vs Austria. It seems it may
have come from here, but Oliver doesn't credit himself as the creator:
https://github.com/kestasjk/webDiplomacy/blob/master/variants/ClassicFvA/variant.php