### PR TITLE
Solo winner function

### DIFF
--- a/variants/ancientmediterranean/ancientmediterranean.go
+++ b/variants/ancientmediterranean/ancientmediterranean.go
@@ -22,19 +22,19 @@ const (
 var Nations = []dip.Nation{Rome, Greece, Egypt, Persia, Carthage}
 
 var AncientMediterraneanVariant = common.Variant{
-	Name:              "Ancient Mediterranean",
-	Graph:             func() dip.Graph { return AncientMediterraneanGraph() },
-	Start:             AncientMediterraneanStart,
-	Blank:             AncientMediterraneanBlank,
-	Phase:             classical.Phase,
-	ParseOrders:       orders.ParseAll,
-	ParseOrder:        orders.Parse,
-	OrderTypes:        orders.OrderTypes(),
-	Nations:           Nations,
-	PhaseTypes:        cla.PhaseTypes,
-	Seasons:           cla.Seasons,
-	UnitTypes:         cla.UnitTypes,
-	SoloSupplyCenters: 18,
+	Name:        "Ancient Mediterranean",
+	Graph:       func() dip.Graph { return AncientMediterraneanGraph() },
+	Start:       AncientMediterraneanStart,
+	Blank:       AncientMediterraneanBlank,
+	Phase:       classical.Phase,
+	ParseOrders: orders.ParseAll,
+	ParseOrder:  orders.Parse,
+	OrderTypes:  orders.OrderTypes(),
+	Nations:     Nations,
+	PhaseTypes:  cla.PhaseTypes,
+	Seasons:     cla.Seasons,
+	UnitTypes:   cla.UnitTypes,
+	SoloWinner:  common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/ancientmediterraneanmap.svg")
 	},

--- a/variants/classical/classical.go
+++ b/variants/classical/classical.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/zond/godip/state"
-	"github.com/zond/godip/variants/common"
 	"github.com/zond/godip/variants/classical/orders"
 	"github.com/zond/godip/variants/classical/start"
+	"github.com/zond/godip/variants/common"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 var ClassicalVariant = common.Variant{
@@ -20,16 +20,16 @@ var ClassicalVariant = common.Variant{
 		result = Blank(Phase(1900, cla.Fall, cla.Adjustment))
 		return
 	},
-	ParseOrders:       orders.ParseAll,
-	ParseOrder:        orders.Parse,
-	Graph:             func() dip.Graph { return start.Graph() },
-	Phase:             Phase,
-	OrderTypes:        orders.OrderTypes(),
-	Nations:           cla.Nations,
-	PhaseTypes:        cla.PhaseTypes,
-	Seasons:           cla.Seasons,
-	UnitTypes:         cla.UnitTypes,
-	SoloSupplyCenters: 18,
+	ParseOrders: orders.ParseAll,
+	ParseOrder:  orders.Parse,
+	Graph:       func() dip.Graph { return start.Graph() },
+	Phase:       Phase,
+	OrderTypes:  orders.OrderTypes(),
+	Nations:     cla.Nations,
+	PhaseTypes:  cla.PhaseTypes,
+	Seasons:     cla.Seasons,
+	UnitTypes:   cla.UnitTypes,
+	SoloWinner:  common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/map.svg")
 	},
@@ -42,11 +42,12 @@ var ClassicalVariant = common.Variant{
 			return Asset("svg/fleet.svg")
 		},
 	},
-	CreatedBy: "Allan B. Calhamer",
-	Version: "",
+	CreatedBy:   "Allan B. Calhamer",
+	Version:     "",
 	Description: "The original game of Diplomacy.",
-	Rules: "The first to 18 supply centers is the winner. See the Wikibooks article for how to play: https://en.wikibooks.org/wiki/Diplomacy/Rules",
+	Rules:       "The first to 18 supply centers is the winner. See the Wikibooks article for how to play: https://en.wikibooks.org/wiki/Diplomacy/Rules",
 }
+
 func Blank(phase dip.Phase) *state.State {
 	return state.New(start.Graph(), phase, BackupRule)
 }

--- a/variants/coldwar/coldwar.go
+++ b/variants/coldwar/coldwar.go
@@ -19,19 +19,19 @@ const (
 var Nations = []dip.Nation{USSR, NATO}
 
 var ColdWarVariant = common.Variant{
-	Name:              "Cold War",
-	Graph:             func() dip.Graph { return ColdWarGraph() },
-	Start:             ColdWarStart,
-	Blank:             ColdWarBlank,
-	Phase:             classical.Phase,
-	ParseOrders:       orders.ParseAll,
-	ParseOrder:        orders.Parse,
-	OrderTypes:        orders.OrderTypes(),
-	Nations:           Nations,
-	PhaseTypes:        cla.PhaseTypes,
-	Seasons:           cla.Seasons,
-	UnitTypes:         cla.UnitTypes,
-	SoloSupplyCenters: 17,
+	Name:        "Cold War",
+	Graph:       func() dip.Graph { return ColdWarGraph() },
+	Start:       ColdWarStart,
+	Blank:       ColdWarBlank,
+	Phase:       classical.Phase,
+	ParseOrders: orders.ParseAll,
+	ParseOrder:  orders.Parse,
+	OrderTypes:  orders.OrderTypes(),
+	Nations:     Nations,
+	PhaseTypes:  cla.PhaseTypes,
+	Seasons:     cla.Seasons,
+	UnitTypes:   cla.UnitTypes,
+	SoloWinner:  common.SCCountWinner(17),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/coldwarmap.svg")
 	},

--- a/variants/common/common.go
+++ b/variants/common/common.go
@@ -74,7 +74,7 @@ func SCCountWinner(soloSupplyCenters int) func(*state.State) dip.Nation {
 			}
 		}
 		// Return the nation if they have more than the required SCs.
-		if leader != "" && scCount[leader] > soloSupplyCenters {
+		if leader != "" && scCount[leader] >= soloSupplyCenters {
 			return leader
 		}
 		return ""

--- a/variants/common/common_test.go
+++ b/variants/common/common_test.go
@@ -1,0 +1,98 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/zond/godip/state"
+
+	dip "github.com/zond/godip/common"
+)
+
+const (
+	Austria dip.Nation = "Austria"
+	England dip.Nation = "England"
+
+	Ankara         dip.Province = "Ankara"
+	Belgium        dip.Province = "Belgium"
+	Constantinople dip.Province = "Constantinople"
+	Denmark        dip.Province = "Denmark"
+	Edinbugh       dip.Province = "Edinburgh"
+)
+
+func init() {
+	dip.Debug = true
+}
+
+func TestSCCountWinner_NothingOwned(t *testing.T) {
+	soloFunction := SCCountWinner(2)
+	s := new(state.State)
+	s.SetSupplyCenters(make(map[dip.Province]dip.Nation))
+
+	winner := soloFunction(s)
+
+	if winner != "" {
+		t.Errorf("Expected no winner, but got %v", winner)
+	}
+}
+
+func TestSCCountWinner_LeaderHasntWon(t *testing.T) {
+	soloFunction := SCCountWinner(2)
+	s := new(state.State)
+	s.SetSupplyCenters(make(map[dip.Province]dip.Nation))
+	s.SetSC(Ankara, Austria)
+
+	winner := soloFunction(s)
+
+	if winner != "" {
+		t.Errorf("Expected no winner, but got %v", winner)
+	}
+}
+
+func TestSCCountWinner_ClearWinner(t *testing.T) {
+	soloFunction := SCCountWinner(2)
+	s := new(state.State)
+	s.SetSupplyCenters(make(map[dip.Province]dip.Nation))
+	s.SetSC(Ankara, Austria)
+	s.SetSC(Belgium, Austria)
+	s.SetSC(Constantinople, England)
+
+	winner := soloFunction(s)
+
+	if winner != Austria {
+		t.Errorf("Expected Austria to win, but got %v", winner)
+	}
+}
+
+func TestSCCountWinner_JointLeader(t *testing.T) {
+	soloFunction := SCCountWinner(2)
+	s := new(state.State)
+	s.SetSupplyCenters(make(map[dip.Province]dip.Nation))
+	s.SetSupplyCenters(make(map[dip.Province]dip.Nation))
+	s.SetSC(Ankara, Austria)
+	s.SetSC(Belgium, Austria)
+	s.SetSC(Constantinople, England)
+	s.SetSC(Denmark, England)
+
+	winner := soloFunction(s)
+
+	if winner != "" {
+		t.Errorf("Expected no winner (since joint leader), but got %v", winner)
+	}
+}
+
+func TestSCCountWinner_SecondPlaceHasAlsoPassedTarget(t *testing.T) {
+	soloFunction := SCCountWinner(2)
+	s := new(state.State)
+	s.SetSupplyCenters(make(map[dip.Province]dip.Nation))
+	s.SetSC(Ankara, Austria)
+	s.SetSC(Belgium, Austria)
+	s.SetSC(Constantinople, England)
+	s.SetSC(Denmark, England)
+	s.SetSC(Edinbugh, England)
+
+	winner := soloFunction(s)
+
+	if winner != England {
+		t.Errorf("Expected England to win, but got %v", winner)
+	}
+}

--- a/variants/fleetrome/fleetrome.go
+++ b/variants/fleetrome/fleetrome.go
@@ -7,8 +7,8 @@ import (
 	"github.com/zond/godip/variants/classical/start"
 	"github.com/zond/godip/variants/common"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 var FleetRomeVariant = common.Variant{
@@ -27,16 +27,16 @@ var FleetRomeVariant = common.Variant{
 		}
 		return
 	},
-	Blank:             classical.Blank,
-	Phase:             classical.Phase,
-	ParseOrders:       orders.ParseAll,
-	ParseOrder:        orders.Parse,
-	OrderTypes:        orders.OrderTypes(),
-	Nations:           cla.Nations,
-	PhaseTypes:        cla.PhaseTypes,
-	Seasons:           cla.Seasons,
-	UnitTypes:         cla.UnitTypes,
-	SoloSupplyCenters: 18,
+	Blank:       classical.Blank,
+	Phase:       classical.Phase,
+	ParseOrders: orders.ParseAll,
+	ParseOrder:  orders.Parse,
+	OrderTypes:  orders.OrderTypes(),
+	Nations:     cla.Nations,
+	PhaseTypes:  cla.PhaseTypes,
+	Seasons:     cla.Seasons,
+	UnitTypes:   cla.UnitTypes,
+	SoloWinner:  common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return classical.Asset("svg/map.svg")
 	},
@@ -49,8 +49,8 @@ var FleetRomeVariant = common.Variant{
 			return classical.Asset("svg/fleet.svg")
 		},
 	},
-	CreatedBy: "Richard Sharp",
-	Version: "",
+	CreatedBy:   "Richard Sharp",
+	Version:     "",
 	Description: "Classical Diplomacy, but Italy starts with a fleet in Rome.",
-	Rules: "The first to 18 supply centers is the winner.  Rules are as per classical Diplomacy, but Italy starts with a fleet in Rome rather than an army.",
+	Rules:       "The first to 18 supply centers is the winner.  Rules are as per classical Diplomacy, but Italy starts with a fleet in Rome rather than an army.",
 }

--- a/variants/franceaustria/franceaustria.go
+++ b/variants/franceaustria/franceaustria.go
@@ -7,8 +7,8 @@ import (
 	"github.com/zond/godip/variants/classical/start"
 	"github.com/zond/godip/variants/common"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 var FranceAustriaVariant = common.Variant{
@@ -52,16 +52,16 @@ var FranceAustriaVariant = common.Variant{
 		})
 		return
 	},
-	Blank:             classical.Blank,
-	Phase:             classical.Phase,
-	ParseOrders:       orders.ParseAll,
-	ParseOrder:        orders.Parse,
-	OrderTypes:        orders.OrderTypes(),
-	Nations:           []dip.Nation{cla.Austria, cla.France},
-	PhaseTypes:        cla.PhaseTypes,
-	Seasons:           cla.Seasons,
-	UnitTypes:         cla.UnitTypes,
-	SoloSupplyCenters: 18,
+	Blank:       classical.Blank,
+	Phase:       classical.Phase,
+	ParseOrders: orders.ParseAll,
+	ParseOrder:  orders.Parse,
+	OrderTypes:  orders.OrderTypes(),
+	Nations:     []dip.Nation{cla.Austria, cla.France},
+	PhaseTypes:  cla.PhaseTypes,
+	Seasons:     cla.Seasons,
+	UnitTypes:   cla.UnitTypes,
+	SoloWinner:  common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return classical.Asset("svg/map.svg")
 	},
@@ -74,8 +74,8 @@ var FranceAustriaVariant = common.Variant{
 			return classical.Asset("svg/fleet.svg")
 		},
 	},
-	CreatedBy: "",
-	Version: "",
+	CreatedBy:   "",
+	Version:     "",
 	Description: "A two player variant on the classical map.",
-	Rules: "The first to 18 supply centers is the winner. The rules are as per classical Diplomacy, but with only France and Austria.",
+	Rules:       "The first to 18 supply centers is the winner. The rules are as per classical Diplomacy, but with only France and Austria.",
 }

--- a/variants/pure/pure.go
+++ b/variants/pure/pure.go
@@ -7,30 +7,30 @@ import (
 	"github.com/zond/godip/variants/classical/orders"
 	"github.com/zond/godip/variants/common"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 var PureVariant = common.Variant{
-	Name: "Pure",
-	Graph: func() dip.Graph { return PureGraph() },
-	Start: PureStart,
-	Blank: PureBlank,
-	Phase:             classical.Phase,
-	ParseOrders:       orders.ParseAll,
-	ParseOrder:        orders.Parse,
-	OrderTypes:        []dip.OrderType{
+	Name:        "Pure",
+	Graph:       func() dip.Graph { return PureGraph() },
+	Start:       PureStart,
+	Blank:       PureBlank,
+	Phase:       classical.Phase,
+	ParseOrders: orders.ParseAll,
+	ParseOrder:  orders.Parse,
+	OrderTypes: []dip.OrderType{
 		cla.Build,
 		cla.Move,
 		cla.Hold,
 		cla.Support,
 		cla.Disband,
 	},
-	Nations:           cla.Nations,
-	PhaseTypes:        cla.PhaseTypes,
-	Seasons:           cla.Seasons,
-	UnitTypes:         []dip.UnitType{cla.Army},
-	SoloSupplyCenters: 4,
+	Nations:    cla.Nations,
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  []dip.UnitType{cla.Army},
+	SoloWinner: common.SCCountWinner(4),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/puremap.svg")
 	},
@@ -40,10 +40,10 @@ var PureVariant = common.Variant{
 			return classical.Asset("svg/army.svg")
 		},
 	},
-	CreatedBy: "Danny Loeb",
-	Version: "vb10",
+	CreatedBy:   "Danny Loeb",
+	Version:     "vb10",
 	Description: "A very minimal version of classical Diplomacy where each country is a single province.",
-	Rules: "Each of the seven nations has a single supply center, and each is adjacent to all of the others. The first player to own four of these centers is the winner.",
+	Rules:       "Each of the seven nations has a single supply center, and each is adjacent to all of the others. The first player to own four of these centers is the winner.",
 }
 
 func PureBlank(phase dip.Phase) *state.State {


### PR DESCRIPTION
Allow a variant to override the solo victory function.  Provide a common function that works for cases where the target is 'first to n supply centers' and only return a winner if this isn't tied.

This functionality is needed for variants where the victory condition is less than half the total supply centers, and also for variants such as USA (http://www.dipwiki.com/index.php?title=USA) where the victory conditions are asymmetric.