### PR TITLE
Parser interface

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -188,6 +188,7 @@ type Order interface {
 	Type() OrderType
 	DisplayType() OrderType
 	Targets() []Province
+	Parse([]string) (Adjudicator, error)
 	Validate(Validator) (Nation, error)
 	Options(Validator, Nation, Province) Options
 	At() time.Time

--- a/orders/parser.go
+++ b/orders/parser.go
@@ -7,26 +7,24 @@ import (
 )
 
 type Parser struct {
-	generators []dip.Order
+	prototypes []dip.Order
 }
 
-func NewParser(generators []dip.Order) Parser {
-	return Parser{generators}
+func NewParser(prototypes []dip.Order) Parser {
+	return Parser{prototypes}
 }
 
 func (self Parser) OrderTypes() (result []dip.OrderType) {
-	result = make([]dip.OrderType, len(self.generators))
-	for index, gen := range self.generators {
-		result[index] = gen.DisplayType()
+	result = make([]dip.OrderType, len(self.prototypes))
+	for index, prototype := range self.prototypes {
+		result[index] = prototype.DisplayType()
 	}
 	return
 }
 
 func (self Parser) Orders() (result []dip.Order) {
-	result = make([]dip.Order, len(self.generators))
-	for index, gen := range self.generators {
-		result[index] = gen
-	}
+	result = make([]dip.Order, len(self.prototypes))
+	copy(result, self.prototypes)
 	return
 }
 
@@ -49,8 +47,8 @@ func (self Parser) ParseAll(orders map[dip.Nation]map[dip.Province][]string) (re
 }
 
 func (self Parser) Parse(bits []string) (result dip.Adjudicator, err error) {
-	for _, generator := range self.generators {
-		result, err := generator.Parse(bits)
+	for _, prototype := range self.Orders() {
+		result, err := prototype.Parse(bits)
 		if result != nil || err != nil {
 			return result, err
 		}

--- a/orders/parser.go
+++ b/orders/parser.go
@@ -7,17 +7,17 @@ import (
 )
 
 type Parser struct {
-	generators []func() dip.Order
+	generators []dip.Order
 }
 
-func NewParser(generators []func() dip.Order) Parser {
+func NewParser(generators []dip.Order) Parser {
 	return Parser{generators}
 }
 
 func (self Parser) OrderTypes() (result []dip.OrderType) {
 	result = make([]dip.OrderType, len(self.generators))
 	for index, gen := range self.generators {
-		result[index] = gen().DisplayType()
+		result[index] = gen.DisplayType()
 	}
 	return
 }
@@ -25,7 +25,7 @@ func (self Parser) OrderTypes() (result []dip.OrderType) {
 func (self Parser) Orders() (result []dip.Order) {
 	result = make([]dip.Order, len(self.generators))
 	for index, gen := range self.generators {
-		result[index] = gen()
+		result[index] = gen
 	}
 	return
 }
@@ -50,7 +50,7 @@ func (self Parser) ParseAll(orders map[dip.Nation]map[dip.Province][]string) (re
 
 func (self Parser) Parse(bits []string) (result dip.Adjudicator, err error) {
 	for _, generator := range self.generators {
-		result, err := generator().Parse(bits)
+		result, err := generator.Parse(bits)
 		if result != nil || err != nil {
 			return result, err
 		}

--- a/orders/parser.go
+++ b/orders/parser.go
@@ -1,0 +1,65 @@
+package orders
+
+import (
+	"fmt"
+
+	dip "github.com/zond/godip/common"
+)
+
+type Parser struct {
+	generators []func() dip.Order
+}
+
+func NewParser(generators []func() dip.Order) Parser {
+	return Parser{generators}
+}
+
+func (self Parser) OrderTypes() (result []dip.OrderType) {
+	result = make([]dip.OrderType, len(self.generators))
+	for index, gen := range self.generators {
+		result[index] = gen().DisplayType()
+	}
+	return
+}
+
+func (self Parser) Orders() (result []dip.Order) {
+	result = make([]dip.Order, len(self.generators))
+	for index, gen := range self.generators {
+		result[index] = gen()
+	}
+	return
+}
+
+func (self Parser) ParseAll(orders map[dip.Nation]map[dip.Province][]string) (result map[dip.Province]dip.Adjudicator, err error) {
+	merr := MultiError{}
+	result = map[dip.Province]dip.Adjudicator{}
+	for _, nationOrders := range orders {
+		for prov, bits := range nationOrders {
+			if parsed, e := self.Parse(append([]string{string(prov)}, bits...)); e == nil {
+				result[prov] = parsed
+			} else {
+				merr = append(merr, e)
+			}
+		}
+	}
+	if len(merr) > 0 {
+		err = merr
+	}
+	return
+}
+
+func (self Parser) Parse(bits []string) (result dip.Adjudicator, err error) {
+	for _, generator := range self.generators {
+		result, err := generator().Parse(bits)
+		if result != nil || err != nil {
+			return result, err
+		}
+	}
+	return nil, fmt.Errorf("Invalid order %+v", bits)
+}
+
+type MultiError []error
+
+func (self MultiError) Error() string {
+	return fmt.Sprint([]error(self))
+}

--- a/variants/ancientmediterranean/ancientmediterranean.go
+++ b/variants/ancientmediterranean/ancientmediterranean.go
@@ -22,19 +22,18 @@ const (
 var Nations = []dip.Nation{Rome, Greece, Egypt, Persia, Carthage}
 
 var AncientMediterraneanVariant = common.Variant{
-	Name:        "Ancient Mediterranean",
-	Graph:       func() dip.Graph { return AncientMediterraneanGraph() },
-	Start:       AncientMediterraneanStart,
-	Blank:       AncientMediterraneanBlank,
-	Phase:       classical.Phase,
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
-	OrderTypes:  orders.OrderTypes(),
-	Nations:     Nations,
-	PhaseTypes:  cla.PhaseTypes,
-	Seasons:     cla.Seasons,
-	UnitTypes:   cla.UnitTypes,
-	SoloWinner:  common.SCCountWinner(18),
+	Name:       "Ancient Mediterranean",
+	Graph:      func() dip.Graph { return AncientMediterraneanGraph() },
+	Start:      AncientMediterraneanStart,
+	Blank:      AncientMediterraneanBlank,
+	Phase:      classical.Phase,
+	Parser:     orders.ClassicalParser,
+	OrderTypes: orders.ClassicalParser.OrderTypes(),
+	Nations:    Nations,
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  cla.UnitTypes,
+	SoloWinner: common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/ancientmediterraneanmap.svg")
 	},

--- a/variants/ancientmediterranean/ancientmediterranean.go
+++ b/variants/ancientmediterranean/ancientmediterranean.go
@@ -28,7 +28,6 @@ var AncientMediterraneanVariant = common.Variant{
 	Blank:      AncientMediterraneanBlank,
 	Phase:      classical.Phase,
 	Parser:     orders.ClassicalParser,
-	OrderTypes: orders.ClassicalParser.OrderTypes(),
 	Nations:    Nations,
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,

--- a/variants/classical/classical.go
+++ b/variants/classical/classical.go
@@ -20,16 +20,15 @@ var ClassicalVariant = common.Variant{
 		result = Blank(Phase(1900, cla.Fall, cla.Adjustment))
 		return
 	},
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
-	Graph:       func() dip.Graph { return start.Graph() },
-	Phase:       Phase,
-	OrderTypes:  orders.OrderTypes(),
-	Nations:     cla.Nations,
-	PhaseTypes:  cla.PhaseTypes,
-	Seasons:     cla.Seasons,
-	UnitTypes:   cla.UnitTypes,
-	SoloWinner:  common.SCCountWinner(18),
+	Parser:     orders.ClassicalParser,
+	Graph:      func() dip.Graph { return start.Graph() },
+	Phase:      Phase,
+	OrderTypes: orders.ClassicalParser.OrderTypes(),
+	Nations:    cla.Nations,
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  cla.UnitTypes,
+	SoloWinner: common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/map.svg")
 	},

--- a/variants/classical/classical.go
+++ b/variants/classical/classical.go
@@ -23,7 +23,6 @@ var ClassicalVariant = common.Variant{
 	Parser:     orders.ClassicalParser,
 	Graph:      func() dip.Graph { return start.Graph() },
 	Phase:      Phase,
-	OrderTypes: orders.ClassicalParser.OrderTypes(),
 	Nations:    cla.Nations,
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,

--- a/variants/classical/orders/build.go
+++ b/variants/classical/orders/build.go
@@ -8,7 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-var BuildGenerator func() dip.Order = func() dip.Order { return &build{} }
+var BuildOrder = &build{}
 
 func Build(source dip.Province, typ dip.UnitType, at time.Time) *build {
 	return &build{

--- a/variants/classical/orders/build.go
+++ b/variants/classical/orders/build.go
@@ -8,9 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-func init() {
-	generators = append(generators, func() dip.Order { return &build{} })
-}
+var BuildGenerator func() dip.Order = func() dip.Order { return &build{} }
 
 func Build(source dip.Province, typ dip.UnitType, at time.Time) *build {
 	return &build{

--- a/variants/classical/orders/build.go
+++ b/variants/classical/orders/build.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 func init() {
@@ -57,6 +57,20 @@ func (self *build) Adjudicate(r dip.Resolver) error {
 		return cla.ErrIllegalBuild
 	}
 	return nil
+}
+
+func (self *build) Parse(bits []string) (dip.Adjudicator, error) {
+	var result dip.Adjudicator
+	var err error
+	if len(bits) > 1 && dip.OrderType(bits[1]) == self.DisplayType() {
+		if len(bits) == 3 {
+			result = Build(dip.Province(bits[0]), dip.UnitType(bits[2]), time.Now())
+		}
+		if result == nil {
+			err = fmt.Errorf("Can't parse as %+v", bits)
+		}
+	}
+	return result, err
 }
 
 func (self *build) Options(v dip.Validator, nation dip.Nation, src dip.Province) (result dip.Options) {

--- a/variants/classical/orders/convoy.go
+++ b/variants/classical/orders/convoy.go
@@ -8,7 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-var ConvoyGenerator func() dip.Order = func() dip.Order { return &convoy{} }
+var ConvoyOrder = &convoy{}
 
 func Convoy(source, from, to dip.Province) *convoy {
 	return &convoy{

--- a/variants/classical/orders/convoy.go
+++ b/variants/classical/orders/convoy.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 func init() {
@@ -57,6 +57,20 @@ func (self *convoy) Adjudicate(r dip.Resolver) error {
 		return cla.ErrConvoyDislodged{breaks[0]}
 	}
 	return nil
+}
+
+func (self *convoy) Parse(bits []string) (dip.Adjudicator, error) {
+	var result dip.Adjudicator
+	var err error
+	if len(bits) > 1 && dip.OrderType(bits[1]) == self.DisplayType() {
+		if len(bits) == 4 {
+			result = Convoy(dip.Province(bits[0]), dip.Province(bits[2]), dip.Province(bits[3]))
+		}
+		if result == nil {
+			err = fmt.Errorf("Can't parse as %+v", bits)
+		}
+	}
+	return result, err
 }
 
 func (self *convoy) Options(v dip.Validator, nation dip.Nation, src dip.Province) (result dip.Options) {

--- a/variants/classical/orders/convoy.go
+++ b/variants/classical/orders/convoy.go
@@ -8,9 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-func init() {
-	generators = append(generators, func() dip.Order { return &convoy{} })
-}
+var ConvoyGenerator func() dip.Order = func() dip.Order { return &convoy{} }
 
 func Convoy(source, from, to dip.Province) *convoy {
 	return &convoy{

--- a/variants/classical/orders/disband.go
+++ b/variants/classical/orders/disband.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 func init() {
@@ -94,6 +94,20 @@ func (self *disband) validateBuildPhase(v dip.Validator) (dip.Nation, error) {
 		return "", cla.ErrMissingDeficit
 	}
 	return unit.Nation, nil
+}
+
+func (self *disband) Parse(bits []string) (dip.Adjudicator, error) {
+	var result dip.Adjudicator
+	var err error
+	if len(bits) > 1 && dip.OrderType(bits[1]) == self.DisplayType() {
+		if len(bits) == 2 {
+			result = Disband(dip.Province(bits[0]), time.Now())
+		}
+		if result == nil {
+			err = fmt.Errorf("Can't parse as %+v", bits)
+		}
+	}
+	return result, err
 }
 
 func (self *disband) Options(v dip.Validator, nation dip.Nation, src dip.Province) (result dip.Options) {

--- a/variants/classical/orders/disband.go
+++ b/variants/classical/orders/disband.go
@@ -8,9 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-func init() {
-	generators = append(generators, func() dip.Order { return &disband{} })
-}
+var DisbandGenerator func() dip.Order = func() dip.Order { return &disband{} }
 
 func Disband(source dip.Province, at time.Time) *disband {
 	return &disband{

--- a/variants/classical/orders/disband.go
+++ b/variants/classical/orders/disband.go
@@ -8,7 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-var DisbandGenerator func() dip.Order = func() dip.Order { return &disband{} }
+var DisbandOrder = &disband{}
 
 func Disband(source dip.Province, at time.Time) *disband {
 	return &disband{

--- a/variants/classical/orders/hold.go
+++ b/variants/classical/orders/hold.go
@@ -8,9 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-func init() {
-	generators = append(generators, func() dip.Order { return &hold{} })
-}
+var HoldGenerator func() dip.Order = func() dip.Order { return &hold{} }
 
 func Hold(source dip.Province) *hold {
 	return &hold{

--- a/variants/classical/orders/hold.go
+++ b/variants/classical/orders/hold.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 func init() {
@@ -48,6 +48,20 @@ func (self *hold) At() time.Time {
 
 func (self *hold) Adjudicate(r dip.Resolver) error {
 	return nil
+}
+
+func (self *hold) Parse(bits []string) (dip.Adjudicator, error) {
+	var result dip.Adjudicator
+	var err error
+	if len(bits) > 1 && dip.OrderType(bits[1]) == self.DisplayType() {
+		if len(bits) == 2 {
+			result = Hold(dip.Province(bits[0]))
+		}
+		if result == nil {
+			err = fmt.Errorf("Can't parse as %+v", bits)
+		}
+	}
+	return result, err
 }
 
 func (self *hold) Options(v dip.Validator, nation dip.Nation, src dip.Province) (result dip.Options) {

--- a/variants/classical/orders/hold.go
+++ b/variants/classical/orders/hold.go
@@ -8,7 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-var HoldGenerator func() dip.Order = func() dip.Order { return &hold{} }
+var HoldOrder = &hold{}
 
 func Hold(source dip.Province) *hold {
 	return &hold{

--- a/variants/classical/orders/move.go
+++ b/variants/classical/orders/move.go
@@ -8,14 +8,12 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-var MoveGenerator func() dip.Order = func() dip.Order { return &move{} }
+var MoveOrder = &move{}
 
-var MoveViaConvoyGenerator func() dip.Order = func() dip.Order {
-	return &move{
-		flags: map[dip.Flag]bool{
-			cla.ViaConvoy: true,
-		},
-	}
+var MoveViaConvoyOrder = &move{
+	flags: map[dip.Flag]bool{
+		cla.ViaConvoy: true,
+	},
 }
 
 func Move(source, dest dip.Province) *move {

--- a/variants/classical/orders/move.go
+++ b/variants/classical/orders/move.go
@@ -8,15 +8,14 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-func init() {
-	generators = append(generators, func() dip.Order { return &move{} })
-	generators = append(generators, func() dip.Order {
-		return &move{
-			flags: map[dip.Flag]bool{
-				cla.ViaConvoy: true,
-			},
-		}
-	})
+var MoveGenerator func() dip.Order = func() dip.Order { return &move{} }
+
+var MoveViaConvoyGenerator func() dip.Order = func() dip.Order {
+	return &move{
+		flags: map[dip.Flag]bool{
+			cla.ViaConvoy: true,
+		},
+	}
 }
 
 func Move(source, dest dip.Province) *move {

--- a/variants/classical/orders/move.go
+++ b/variants/classical/orders/move.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
+	cla "github.com/zond/godip/variants/classical/common"
 )
 
 func init() {
@@ -252,6 +252,31 @@ func (self *move) validateMovementPhase(v dip.Validator) (dip.Nation, error) {
 		return "", err
 	}
 	return unit.Nation, nil
+}
+
+func (self *move) Parse(bits []string) (dip.Adjudicator, error) {
+	var result dip.Adjudicator
+	var err error
+	if !self.flags[cla.ViaConvoy] {
+		if len(bits) > 1 && dip.OrderType(bits[1]) == self.DisplayType() {
+			if len(bits) == 3 {
+				result = Move(dip.Province(bits[0]), dip.Province(bits[2]))
+			}
+			if result == nil {
+				err = fmt.Errorf("Can't parse as %+v", bits)
+			}
+		}
+	} else {
+		if len(bits) > 1 && dip.OrderType(bits[1]) == self.DisplayType() {
+			if len(bits) == 3 {
+				result = Move(dip.Province(bits[0]), dip.Province(bits[2])).ViaConvoy()
+			}
+			if result == nil {
+				err = fmt.Errorf("Can't parse as %+v", bits)
+			}
+		}
+	}
+	return result, err
 }
 
 func (self *move) Options(v dip.Validator, nation dip.Nation, src dip.Province) (result dip.Options) {

--- a/variants/classical/orders/orders.go
+++ b/variants/classical/orders/orders.go
@@ -1,61 +1,19 @@
 package orders
 
 import (
-	"fmt"
+	"github.com/zond/godip/orders"
 
 	dip "github.com/zond/godip/common"
 )
 
-var orderTypes []dip.OrderType
-
-var generators []func() dip.Order
-
-func OrderTypes() (result []dip.OrderType) {
-	result = make([]dip.OrderType, len(generators))
-	for index, gen := range generators {
-		result[index] = gen().DisplayType()
-	}
-	return
+var generators = []func() dip.Order{
+	BuildGenerator,
+	ConvoyGenerator,
+	DisbandGenerator,
+	HoldGenerator,
+	MoveGenerator,
+	MoveViaConvoyGenerator,
+	SupportGenerator,
 }
 
-func Orders() (result []dip.Order) {
-	result = make([]dip.Order, len(generators))
-	for index, gen := range generators {
-		result[index] = gen()
-	}
-	return
-}
-
-type MultiError []error
-
-func (self MultiError) Error() string {
-	return fmt.Sprint([]error(self))
-}
-
-func ParseAll(orders map[dip.Nation]map[dip.Province][]string) (result map[dip.Province]dip.Adjudicator, err error) {
-	merr := MultiError{}
-	result = map[dip.Province]dip.Adjudicator{}
-	for _, nationOrders := range orders {
-		for prov, bits := range nationOrders {
-			if parsed, e := Parse(append([]string{string(prov)}, bits...)); e == nil {
-				result[prov] = parsed
-			} else {
-				merr = append(merr, e)
-			}
-		}
-	}
-	if len(merr) > 0 {
-		err = merr
-	}
-	return
-}
-
-func Parse(bits []string) (result dip.Adjudicator, err error) {
-	for _, generator := range generators {
-		result, err := generator().Parse(bits)
-		if result != nil || err != nil {
-			return result, err
-		}
-	}
-	return nil, fmt.Errorf("Invalid order %+v", bits)
-}
+var ClassicalParser = orders.NewParser(generators)

--- a/variants/classical/orders/orders.go
+++ b/variants/classical/orders/orders.go
@@ -2,9 +2,7 @@ package orders
 
 import (
 	"fmt"
-	"time"
 
-	cla "github.com/zond/godip/variants/classical/common"
 	dip "github.com/zond/godip/common"
 )
 
@@ -53,44 +51,11 @@ func ParseAll(orders map[dip.Nation]map[dip.Province][]string) (result map[dip.P
 }
 
 func Parse(bits []string) (result dip.Adjudicator, err error) {
-	if len(bits) > 1 {
-		switch dip.OrderType(bits[1]) {
-		case (&build{}).DisplayType():
-			if len(bits) == 3 {
-				result = Build(dip.Province(bits[0]), dip.UnitType(bits[2]), time.Now())
-			}
-		case (&convoy{}).DisplayType():
-			if len(bits) == 4 {
-				result = Convoy(dip.Province(bits[0]), dip.Province(bits[2]), dip.Province(bits[3]))
-			}
-		case (&disband{}).DisplayType():
-			if len(bits) == 2 {
-				result = Disband(dip.Province(bits[0]), time.Now())
-			}
-		case (&hold{}).DisplayType():
-			if len(bits) == 2 {
-				result = Hold(dip.Province(bits[0]))
-			}
-		case (&move{}).DisplayType():
-			if len(bits) == 3 {
-				result = Move(dip.Province(bits[0]), dip.Province(bits[2]))
-			}
-		case (&move{flags: map[dip.Flag]bool{cla.ViaConvoy: true}}).DisplayType():
-			if len(bits) == 3 {
-				result = Move(dip.Province(bits[0]), dip.Province(bits[2])).ViaConvoy()
-			}
-		case (&support{}).DisplayType():
-			if len(bits) == 4 {
-				if bits[2] == bits[3] {
-					result = SupportHold(dip.Province(bits[0]), dip.Province(bits[2]))
-				} else {
-					result = SupportMove(dip.Province(bits[0]), dip.Province(bits[2]), dip.Province(bits[3]))
-				}
-			}
+	for _, generator := range generators {
+		result, err := generator().Parse(bits)
+		if result != nil || err != nil {
+			return result, err
 		}
 	}
-	if result == nil {
-		err = fmt.Errorf("Invalid order %+v", bits)
-	}
-	return
+	return nil, fmt.Errorf("Invalid order %+v", bits)
 }

--- a/variants/classical/orders/orders.go
+++ b/variants/classical/orders/orders.go
@@ -6,14 +6,12 @@ import (
 	dip "github.com/zond/godip/common"
 )
 
-var generators = []func() dip.Order{
-	BuildGenerator,
-	ConvoyGenerator,
-	DisbandGenerator,
-	HoldGenerator,
-	MoveGenerator,
-	MoveViaConvoyGenerator,
-	SupportGenerator,
-}
-
-var ClassicalParser = orders.NewParser(generators)
+var ClassicalParser = orders.NewParser([]dip.Order{
+	BuildOrder,
+	ConvoyOrder,
+	DisbandOrder,
+	HoldOrder,
+	MoveOrder,
+	MoveViaConvoyOrder,
+	SupportOrder,
+})

--- a/variants/classical/orders/support.go
+++ b/variants/classical/orders/support.go
@@ -8,7 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-var SupportGenerator func() dip.Order = func() dip.Order { return &support{} }
+var SupportOrder = &support{}
 
 func SupportHold(prov, target dip.Province) *support {
 	return &support{

--- a/variants/classical/orders/support.go
+++ b/variants/classical/orders/support.go
@@ -85,6 +85,24 @@ func (self *support) Adjudicate(r dip.Resolver) error {
 	return nil
 }
 
+func (self *support) Parse(bits []string) (dip.Adjudicator, error) {
+	var result dip.Adjudicator
+	var err error
+	if len(bits) > 1 && dip.OrderType(bits[1]) == self.DisplayType() {
+		if len(bits) == 4 {
+			if bits[2] == bits[3] {
+				result = SupportHold(dip.Province(bits[0]), dip.Province(bits[2]))
+			} else {
+				result = SupportMove(dip.Province(bits[0]), dip.Province(bits[2]), dip.Province(bits[3]))
+			}
+		}
+		if result == nil {
+			err = fmt.Errorf("Can't parse as %+v", bits)
+		}
+	}
+	return result, err
+}
+
 func (self *support) Options(v dip.Validator, nation dip.Nation, src dip.Province) (result dip.Options) {
 	if src.Super() != src {
 		return

--- a/variants/classical/orders/support.go
+++ b/variants/classical/orders/support.go
@@ -8,9 +8,7 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-func init() {
-	generators = append(generators, func() dip.Order { return &support{} })
-}
+var SupportGenerator func() dip.Order = func() dip.Order { return &support{} }
 
 func SupportHold(prov, target dip.Province) *support {
 	return &support{

--- a/variants/classical/phase.go
+++ b/variants/classical/phase.go
@@ -27,7 +27,7 @@ func (self *phase) String() string {
 }
 
 func (self *phase) Options(s dip.Validator, nation dip.Nation) (result dip.Options) {
-	return s.Options(orders.Orders(), nation)
+	return s.Options(orders.ClassicalParser.Orders(), nation)
 }
 
 func (self *phase) Winner(s dip.Validator) *dip.Nation {

--- a/variants/coldwar/coldwar.go
+++ b/variants/coldwar/coldwar.go
@@ -25,7 +25,6 @@ var ColdWarVariant = common.Variant{
 	Blank:      ColdWarBlank,
 	Phase:      classical.Phase,
 	Parser:     orders.ClassicalParser,
-	OrderTypes: orders.ClassicalParser.OrderTypes(),
 	Nations:    Nations,
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,

--- a/variants/coldwar/coldwar.go
+++ b/variants/coldwar/coldwar.go
@@ -19,19 +19,18 @@ const (
 var Nations = []dip.Nation{USSR, NATO}
 
 var ColdWarVariant = common.Variant{
-	Name:        "Cold War",
-	Graph:       func() dip.Graph { return ColdWarGraph() },
-	Start:       ColdWarStart,
-	Blank:       ColdWarBlank,
-	Phase:       classical.Phase,
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
-	OrderTypes:  orders.OrderTypes(),
-	Nations:     Nations,
-	PhaseTypes:  cla.PhaseTypes,
-	Seasons:     cla.Seasons,
-	UnitTypes:   cla.UnitTypes,
-	SoloWinner:  common.SCCountWinner(17),
+	Name:       "Cold War",
+	Graph:      func() dip.Graph { return ColdWarGraph() },
+	Start:      ColdWarStart,
+	Blank:      ColdWarBlank,
+	Phase:      classical.Phase,
+	Parser:     orders.ClassicalParser,
+	OrderTypes: orders.ClassicalParser.OrderTypes(),
+	Nations:    Nations,
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  cla.UnitTypes,
+	SoloWinner: common.SCCountWinner(17),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/coldwarmap.svg")
 	},

--- a/variants/common/common.go
+++ b/variants/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/zond/godip/orders"
 	"github.com/zond/godip/state"
 
 	dip "github.com/zond/godip/common"
@@ -18,10 +19,8 @@ type Variant struct {
 	Blank func(dip.Phase) *state.State `json:"-"`
 	// Phase returns a phase with the provided year, season and phase type for this variant.
 	Phase func(int, dip.Season, dip.PhaseType) dip.Phase `json:"-"`
-	// ParserOrders parses a map of orders.
-	ParseOrders func(map[dip.Nation]map[dip.Province][]string) (map[dip.Province]dip.Adjudicator, error) `json:"-"`
-	// ParseOrder parses a single tokenized order.
-	ParseOrder func([]string) (dip.Adjudicator, error) `json:"-"`
+	// Parser for orders in the variant.
+	Parser orders.Parser `json:"-"`
 	// Graph is the graph for this variant.
 	Graph func() dip.Graph `json:"-"`
 	// Nations are the nations playing this variant.

--- a/variants/common/common.go
+++ b/variants/common/common.go
@@ -31,8 +31,6 @@ type Variant struct {
 	Seasons []dip.Season
 	// UnitTypes are the types the units of this variant have.
 	UnitTypes []dip.UnitType
-	// OrderTypes are the types the orders of this variant have.
-	OrderTypes []dip.OrderType
 	// Function to return a nation with a solo (or the empty string if no such nation exists).
 	SoloWinner func(*state.State) dip.Nation `json:"-"`
 	// SVG representing the variant map graphics.

--- a/variants/fleetrome/fleetrome.go
+++ b/variants/fleetrome/fleetrome.go
@@ -27,16 +27,15 @@ var FleetRomeVariant = common.Variant{
 		}
 		return
 	},
-	Blank:       classical.Blank,
-	Phase:       classical.Phase,
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
-	OrderTypes:  orders.OrderTypes(),
-	Nations:     cla.Nations,
-	PhaseTypes:  cla.PhaseTypes,
-	Seasons:     cla.Seasons,
-	UnitTypes:   cla.UnitTypes,
-	SoloWinner:  common.SCCountWinner(18),
+	Blank:      classical.Blank,
+	Phase:      classical.Phase,
+	Parser:     orders.ClassicalParser,
+	OrderTypes: orders.ClassicalParser.OrderTypes(),
+	Nations:    cla.Nations,
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  cla.UnitTypes,
+	SoloWinner: common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return classical.Asset("svg/map.svg")
 	},

--- a/variants/fleetrome/fleetrome.go
+++ b/variants/fleetrome/fleetrome.go
@@ -30,7 +30,6 @@ var FleetRomeVariant = common.Variant{
 	Blank:      classical.Blank,
 	Phase:      classical.Phase,
 	Parser:     orders.ClassicalParser,
-	OrderTypes: orders.ClassicalParser.OrderTypes(),
 	Nations:    cla.Nations,
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,

--- a/variants/franceaustria/franceaustria.go
+++ b/variants/franceaustria/franceaustria.go
@@ -55,7 +55,6 @@ var FranceAustriaVariant = common.Variant{
 	Blank:      classical.Blank,
 	Phase:      classical.Phase,
 	Parser:     orders.ClassicalParser,
-	OrderTypes: orders.ClassicalParser.OrderTypes(),
 	Nations:    []dip.Nation{cla.Austria, cla.France},
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,

--- a/variants/franceaustria/franceaustria.go
+++ b/variants/franceaustria/franceaustria.go
@@ -52,16 +52,15 @@ var FranceAustriaVariant = common.Variant{
 		})
 		return
 	},
-	Blank:       classical.Blank,
-	Phase:       classical.Phase,
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
-	OrderTypes:  orders.OrderTypes(),
-	Nations:     []dip.Nation{cla.Austria, cla.France},
-	PhaseTypes:  cla.PhaseTypes,
-	Seasons:     cla.Seasons,
-	UnitTypes:   cla.UnitTypes,
-	SoloWinner:  common.SCCountWinner(18),
+	Blank:      classical.Blank,
+	Phase:      classical.Phase,
+	Parser:     orders.ClassicalParser,
+	OrderTypes: orders.ClassicalParser.OrderTypes(),
+	Nations:    []dip.Nation{cla.Austria, cla.France},
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  cla.UnitTypes,
+	SoloWinner: common.SCCountWinner(18),
 	SVGMap: func() ([]byte, error) {
 		return classical.Asset("svg/map.svg")
 	},

--- a/variants/generator/README.md
+++ b/variants/generator/README.md
@@ -90,7 +90,7 @@ bindata.go file (see the main README for more details).  Update the variants.go 
 
 The map may need some manual tweaks (e.g. to add canals, coasts or other details), and once this is done then you can generate the bindata.go file.
 
-You can generate some other maps to check that everything generally looks right by running `go test -v ./...` from the variants directory, and looking in the `test_output_maps` directory afterwards. One
+You can generate some other maps to check that everything generally looks right by running `env DRAW_MAPS=true go test -v ./...` from the variants directory, and looking in the `test_output_maps` directory afterwards. One
 thing to look out for is erroneous sea-connections between coastal regions that fleets shouldn't be able to travel between.
 
 #### Add variant tests

--- a/variants/generator/generate.py
+++ b/variants/generator/generate.py
@@ -794,20 +794,19 @@ const (
         f.write('\t{{0:<{}}} dip.Nation = "{{0}}"\n'.format(nationLength).format(nation))
     f.write(')\n\nvar Nations = []dip.Nation{{{}}}\n'.format(', '.join(START_UNITS.keys())))
     f.write('\nvar {}Variant = common.Variant{{\n'.format(VARIANT.replace(' ', '')))
-    f.write('\tName:        "{}",\n'.format(VARIANT))
-    f.write('\tGraph:       func() dip.Graph {{ return {}Graph() }},\n'.format(VARIANT.replace(' ', '')))
-    f.write('\tStart:       {}Start,\n'.format(VARIANT.replace(' ', '')))
-    f.write('\tBlank:       {}Blank,\n'.format(VARIANT.replace(' ', '')))
-    f.write("""	Phase:       classical.Phase,
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
-	OrderTypes:  orders.OrderTypes(),
-	Nations:     Nations,
-	PhaseTypes:  cla.PhaseTypes,
-	Seasons:     cla.Seasons,
-	UnitTypes:   cla.UnitTypes,""")
+    f.write('\tName:       "{}",\n'.format(VARIANT))
+    f.write('\tGraph:      func() dip.Graph {{ return {}Graph() }},\n'.format(VARIANT.replace(' ', '')))
+    f.write('\tStart:      {}Start,\n'.format(VARIANT.replace(' ', '')))
+    f.write('\tBlank:      {}Blank,\n'.format(VARIANT.replace(' ', '')))
+    f.write("""	Phase:      classical.Phase,
+	Parser:     orders.ClassicalParser,
+	OrderTypes: orders.ClassicalParser.OrderTypes(),
+	Nations:    Nations,
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  cla.UnitTypes,""")
     scCount = int(round(len([province for province in provinces if province.flags.supplyCenter]) / 2.0))
-    f.write('\n\tSoloWinner:  common.SCCountWinner({}),\n'.format(scCount))
+    f.write('\n\tSoloWinner: common.SCCountWinner({}),\n'.format(scCount))
     f.write("""	SVGMap: func() ([]byte, error) {{
 		return Asset("svg/{}map.svg")
 	}},

--- a/variants/pure/pure.go
+++ b/variants/pure/pure.go
@@ -12,13 +12,12 @@ import (
 )
 
 var PureVariant = common.Variant{
-	Name:        "Pure",
-	Graph:       func() dip.Graph { return PureGraph() },
-	Start:       PureStart,
-	Blank:       PureBlank,
-	Phase:       classical.Phase,
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
+	Name:   "Pure",
+	Graph:  func() dip.Graph { return PureGraph() },
+	Start:  PureStart,
+	Blank:  PureBlank,
+	Phase:  classical.Phase,
+	Parser: orders.ClassicalParser,
 	OrderTypes: []dip.OrderType{
 		cla.Build,
 		cla.Move,

--- a/variants/pure/pure.go
+++ b/variants/pure/pure.go
@@ -12,15 +12,13 @@ import (
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
-var generators = []func() dip.Order{
-	orders.BuildGenerator,
-	orders.MoveGenerator,
-	orders.HoldGenerator,
-	orders.SupportGenerator,
-	orders.DisbandGenerator,
-}
-
-var pureParser = ord.NewParser(generators)
+var pureParser = ord.NewParser([]dip.Order{
+	orders.BuildOrder,
+	orders.DisbandOrder,
+	orders.HoldOrder,
+	orders.MoveOrder,
+	orders.SupportOrder,
+})
 
 var PureVariant = common.Variant{
 	Name:       "Pure",

--- a/variants/pure/pure.go
+++ b/variants/pure/pure.go
@@ -8,23 +8,28 @@ import (
 	"github.com/zond/godip/variants/common"
 
 	dip "github.com/zond/godip/common"
+	ord "github.com/zond/godip/orders"
 	cla "github.com/zond/godip/variants/classical/common"
 )
 
+var generators = []func() dip.Order{
+	orders.BuildGenerator,
+	orders.MoveGenerator,
+	orders.HoldGenerator,
+	orders.SupportGenerator,
+	orders.DisbandGenerator,
+}
+
+var pureParser = ord.NewParser(generators)
+
 var PureVariant = common.Variant{
-	Name:   "Pure",
-	Graph:  func() dip.Graph { return PureGraph() },
-	Start:  PureStart,
-	Blank:  PureBlank,
-	Phase:  classical.Phase,
-	Parser: orders.ClassicalParser,
-	OrderTypes: []dip.OrderType{
-		cla.Build,
-		cla.Move,
-		cla.Hold,
-		cla.Support,
-		cla.Disband,
-	},
+	Name:       "Pure",
+	Graph:      func() dip.Graph { return PureGraph() },
+	Start:      PureStart,
+	Blank:      PureBlank,
+	Phase:      classical.Phase,
+	Parser:     pureParser,
+	OrderTypes: pureParser.OrderTypes(),
 	Nations:    cla.Nations,
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,

--- a/variants/pure/pure.go
+++ b/variants/pure/pure.go
@@ -27,7 +27,6 @@ var PureVariant = common.Variant{
 	Blank:      PureBlank,
 	Phase:      classical.Phase,
 	Parser:     pureParser,
-	OrderTypes: pureParser.OrderTypes(),
 	Nations:    cla.Nations,
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,

--- a/variants/youngstownredux/youngstownredux.go
+++ b/variants/youngstownredux/youngstownredux.go
@@ -27,19 +27,18 @@ const (
 var Nations = []dip.Nation{Turkey, Austria, Britain, China, Japan, Italy, Germany, India, Russia, France}
 
 var YoungstownReduxVariant = common.Variant{
-	Name:        "Youngstown Redux",
-	Graph:       func() dip.Graph { return YoungstownReduxGraph() },
-	Start:       YoungstownReduxStart,
-	Blank:       YoungstownReduxBlank,
-	Phase:       classical.Phase,
-	ParseOrders: orders.ParseAll,
-	ParseOrder:  orders.Parse,
-	OrderTypes:  orders.OrderTypes(),
-	Nations:     Nations,
-	PhaseTypes:  cla.PhaseTypes,
-	Seasons:     cla.Seasons,
-	UnitTypes:   cla.UnitTypes,
-	SoloWinner:  common.SCCountWinner(28),
+	Name:       "Youngstown Redux",
+	Graph:      func() dip.Graph { return YoungstownReduxGraph() },
+	Start:      YoungstownReduxStart,
+	Blank:      YoungstownReduxBlank,
+	Phase:      classical.Phase,
+	Parser:     orders.ClassicalParser,
+	OrderTypes: orders.ClassicalParser.OrderTypes(),
+	Nations:    Nations,
+	PhaseTypes: cla.PhaseTypes,
+	Seasons:    cla.Seasons,
+	UnitTypes:  cla.UnitTypes,
+	SoloWinner: common.SCCountWinner(28),
 	SVGMap: func() ([]byte, error) {
 		return Asset("svg/youngstownreduxmap.svg")
 	},

--- a/variants/youngstownredux/youngstownredux.go
+++ b/variants/youngstownredux/youngstownredux.go
@@ -33,7 +33,6 @@ var YoungstownReduxVariant = common.Variant{
 	Blank:      YoungstownReduxBlank,
 	Phase:      classical.Phase,
 	Parser:     orders.ClassicalParser,
-	OrderTypes: orders.ClassicalParser.OrderTypes(),
 	Nations:    Nations,
 	PhaseTypes: cla.PhaseTypes,
 	Seasons:    cla.Seasons,


### PR DESCRIPTION
Make it easy for variants to declare the set of orders they support. Create a new Parser interface and a ClassicalParser for the existing variants to use.