### PR TITLE
Unified how the order corroboration and phase messages compute expected/allowed build orders.

### DIFF
--- a/godip.go
+++ b/godip.go
@@ -42,9 +42,9 @@ const (
 	Support       OrderType = "Support"
 	Disband       OrderType = "Disband"
 
-	ViaConvoy     Flag = "C"
-	Anywhere      Flag = "A"
-	AnyHomeCenter Flag = "H"
+	ViaConvoy     Flag = "ViaConvoy"
+	Anywhere      Flag = "Anywhere"
+	AnyHomeCenter Flag = "AnyHomeCenter"
 )
 
 var (
@@ -478,6 +478,8 @@ type Validator interface {
 	GetProfile() (map[string]time.Duration, map[string]int)
 
 	MemoizeProvSlice(string, func() []Province) []Province
+
+	Flags() map[Flag]bool
 }
 
 // Resolver is what validators turn into when adjudication has started.

--- a/state/judge_test.go
+++ b/state/judge_test.go
@@ -67,7 +67,7 @@ func assertOrderLocation(t *testing.T, j *State, prov godip.Province, order godi
 }
 
 func TestStateLocations(t *testing.T) {
-	j := New(testGraph(), nil, nil, nil)
+	j := New(testGraph(), nil, nil, nil, nil)
 	j.SetOrders(map[godip.Province]godip.Adjudicator{
 		"a":    testOrder(1),
 		"b/ec": testOrder(2),

--- a/state/state.go
+++ b/state/state.go
@@ -7,7 +7,7 @@ import (
 	"github.com/zond/godip"
 )
 
-func New(graph godip.Graph, phase godip.Phase, backupRule godip.BackupRule, neutralOrders func(State) map[godip.Province]godip.Adjudicator) *State {
+func New(graph godip.Graph, phase godip.Phase, backupRule godip.BackupRule, flags map[godip.Flag]bool, neutralOrders func(State) map[godip.Province]godip.Adjudicator) *State {
 	return &State{
 		graph:              graph,
 		phase:              phase,
@@ -23,6 +23,7 @@ func New(graph godip.Graph, phase godip.Phase, backupRule godip.BackupRule, neut
 		profile:            make(map[string]time.Duration),
 		profileCounts:      make(map[string]int),
 		memoizedProvSlices: make(map[string][]godip.Province),
+		flags:              flags,
 	}
 }
 
@@ -80,6 +81,7 @@ type State struct {
 	profile            map[string]time.Duration
 	profileCounts      map[string]int
 	memoizedProvSlices map[string][]godip.Province
+	flags              map[godip.Flag]bool
 }
 
 func (self *State) Profile(a string, t time.Time) {
@@ -95,6 +97,10 @@ func (self *State) MemoizeProvSlice(key string, f func() []godip.Province) []god
 	neu := f()
 	self.memoizedProvSlices[key] = neu
 	return neu
+}
+
+func (self *State) Flags() map[godip.Flag]bool {
+	return self.flags
 }
 
 func (self *State) GetProfile() (map[string]time.Duration, map[string]int) {

--- a/variants/ancientmediterranean/ancientmediterranean.go
+++ b/variants/ancientmediterranean/ancientmediterranean.go
@@ -54,7 +54,7 @@ var AncientMediterraneanVariant = common.Variant{
 }
 
 func AncientMediterraneanBlank(phase godip.Phase) *state.State {
-	return state.New(AncientMediterraneanGraph(), phase, classical.BackupRule, nil)
+	return state.New(AncientMediterraneanGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func AncientMediterraneanStart() (result *state.State, err error) {

--- a/variants/canton/canton.go
+++ b/variants/canton/canton.go
@@ -55,7 +55,7 @@ var CantonVariant = common.Variant{
 }
 
 func CantonBlank(phase godip.Phase) *state.State {
-	return state.New(CantonGraph(), phase, classical.BackupRule, nil)
+	return state.New(CantonGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func CantonStart() (result *state.State, err error) {

--- a/variants/chaos/chaos.go
+++ b/variants/chaos/chaos.go
@@ -255,7 +255,7 @@ func Graph() *graph.Graph {
 }
 
 func Blank(phase godip.Phase) *state.State {
-	return state.New(Graph(), phase, classical.BackupRule, nil)
+	return state.New(Graph(), phase, classical.BackupRule, map[godip.Flag]bool{godip.Anywhere: true}, nil)
 }
 
 func Start() (*state.State, error) {

--- a/variants/classical/classical.go
+++ b/variants/classical/classical.go
@@ -99,7 +99,7 @@ var ClassicalVariant = common.Variant{
 }
 
 func Blank(phase godip.Phase) *state.State {
-	return state.New(start.Graph(), phase, BackupRule, nil)
+	return state.New(start.Graph(), phase, BackupRule, nil, nil)
 }
 
 func Start() (result *state.State, err error) {

--- a/variants/classical/phase_message_test.go
+++ b/variants/classical/phase_message_test.go
@@ -79,9 +79,9 @@ func TestPhaseMessage(t *testing.T) {
 
 	s = Blank(NewPhase(1903, godip.Fall, godip.Adjustment))
 	s.SetSC("lon", godip.France)
-	s.SetSC("ber", godip.France)
-	s.SetSC("mos", godip.France)
-	s.SetSC("con", godip.France)
+	s.SetSC("par", godip.France)
+	s.SetSC("bre", godip.France)
+	s.SetSC("mar", godip.France)
 	ver(godip.France, []string{"MayBuild:3", "OtherMayBuild:Austria:0", "OtherMayBuild:England:0", "OtherMayBuild:Germany:0", "OtherMayBuild:Italy:0", "OtherMayBuild:Turkey:0", "OtherMayBuild:Russia:0"})
 	ver(godip.Italy, []string{"MayBuild:0", "OtherMayBuild:Austria:0", "OtherMayBuild:England:0", "OtherMayBuild:Germany:0", "OtherMayBuild:France:3", "OtherMayBuild:Turkey:0", "OtherMayBuild:Russia:0"})
 

--- a/variants/coldwar/coldwar.go
+++ b/variants/coldwar/coldwar.go
@@ -64,7 +64,7 @@ var ColdWarVariant = common.Variant{
 }
 
 func ColdWarBlank(phase godip.Phase) *state.State {
-	return state.New(ColdWarGraph(), phase, classical.BackupRule, nil)
+	return state.New(ColdWarGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func ColdWarStart() (result *state.State, err error) {

--- a/variants/empiresandcoalitions/empiresandcoalitions.go
+++ b/variants/empiresandcoalitions/empiresandcoalitions.go
@@ -59,7 +59,7 @@ var EmpiresAndCoalitionsVariant = common.Variant{
 }
 
 func EmpiresAndCoalitionsBlank(phase godip.Phase) *state.State {
-	return state.New(EmpiresAndCoalitionsGraph(), phase, classical.BackupRule, nil)
+	return state.New(EmpiresAndCoalitionsGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func EmpiresAndCoalitionsStart() (result *state.State, err error) {

--- a/variants/europe1939/europe1939.go
+++ b/variants/europe1939/europe1939.go
@@ -57,7 +57,7 @@ var Europe1939Variant = common.Variant{
 }
 
 func Europe1939Blank(phase godip.Phase) *state.State {
-	return state.New(Europe1939Graph(), phase, classical.BackupRule, nil)
+	return state.New(Europe1939Graph(), phase, classical.BackupRule, nil, nil)
 }
 
 func Europe1939Start() (result *state.State, err error) {

--- a/variants/generator/variant.go.template
+++ b/variants/generator/variant.go.template
@@ -47,7 +47,7 @@ var ${variant_camel}Variant = common.Variant{
 }
 
 func ${variant_camel}Blank(phase godip.Phase) *state.State {
-	return state.New(${variant_camel}Graph(), phase, classical.BackupRule, nil)
+	return state.New(${variant_camel}Graph(), phase, classical.BackupRule, nil, nil)
 }
 
 func ${variant_camel}Start() (result *state.State, err error) {

--- a/variants/hundred/hundred.go
+++ b/variants/hundred/hundred.go
@@ -76,7 +76,7 @@ var HundredVariant = common.Variant{
 }
 
 func HundredBlank(phase godip.Phase) *state.State {
-	return state.New(HundredGraph(), phase, classical.BackupRule, nil)
+	return state.New(HundredGraph(), phase, classical.BackupRule, map[godip.Flag]bool{godip.Anywhere: true}, nil)
 }
 
 func HundredStart() (result *state.State, err error) {

--- a/variants/northseawars/northseawars.go
+++ b/variants/northseawars/northseawars.go
@@ -53,7 +53,7 @@ var NorthSeaWarsVariant = common.Variant{
 }
 
 func NorthSeaWarsBlank(phase godip.Phase) *state.State {
-	return state.New(NorthSeaWarsGraph(), phase, classical.BackupRule, nil)
+	return state.New(NorthSeaWarsGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func NorthSeaWarsStart() (result *state.State, err error) {

--- a/variants/pure/pure.go
+++ b/variants/pure/pure.go
@@ -58,7 +58,7 @@ var PureVariant = common.Variant{
 }
 
 func PureBlank(phase godip.Phase) *state.State {
-	return state.New(PureGraph(), phase, classical.BackupRule, nil)
+	return state.New(PureGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func PureStart() (result *state.State, err error) {

--- a/variants/twentytwenty/twentytwenty.go
+++ b/variants/twentytwenty/twentytwenty.go
@@ -200,7 +200,7 @@ Thirteen provinces have dual coasts: Whitehorse, Los Angeles, Mexico, Colombia, 
 var Phase = phase.Generator(BuildAnyHomeCenterParser, classical.AdjustSCs)
 
 func TwentyTwentyBlank(phase godip.Phase) *state.State {
-	return state.New(TwentyTwentyGraph(), phase, classical.BackupRule, nil)
+	return state.New(TwentyTwentyGraph(), phase, classical.BackupRule, map[godip.Flag]bool{godip.AnyHomeCenter: true}, nil)
 }
 
 func TwentyTwentyStart() (result *state.State, err error) {

--- a/variants/vietnamwar/vietnamwar.go
+++ b/variants/vietnamwar/vietnamwar.go
@@ -72,7 +72,7 @@ Two provinces have dual coasts: Xuyen and Mekong (South coast and River).`,
 }
 
 func VietnamWarBlank(phase godip.Phase) *state.State {
-	return state.New(VietnamWarGraph(), phase, classical.BackupRule, nil)
+	return state.New(VietnamWarGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func VietnamWarStart() (result *state.State, err error) {

--- a/variants/westernworld901/westernworld901.go
+++ b/variants/westernworld901/westernworld901.go
@@ -94,7 +94,7 @@ func NeutralOrders(state state.State) (ret map[godip.Province]godip.Adjudicator)
 }
 
 func WesternWorld901Blank(phase godip.Phase) *state.State {
-	return state.New(WesternWorld901Graph(), phase, classical.BackupRule, NeutralOrders)
+	return state.New(WesternWorld901Graph(), phase, classical.BackupRule, map[godip.Flag]bool{godip.Anywhere: true}, NeutralOrders)
 }
 
 func WesternWorld901Start() (result *state.State, err error) {

--- a/variants/year1908/year1908.go
+++ b/variants/year1908/year1908.go
@@ -57,7 +57,7 @@ var Year1908Variant = common.Variant{
 }
 
 func Year1908Blank(phase godip.Phase) *state.State {
-	return state.New(Year1908Graph(), phase, classical.BackupRule, nil)
+	return state.New(Year1908Graph(), phase, classical.BackupRule, nil, nil)
 }
 
 func Year1908Start() (result *state.State, err error) {

--- a/variants/youngstownredux/youngstownredux.go
+++ b/variants/youngstownredux/youngstownredux.go
@@ -59,7 +59,7 @@ The Arctic region is impassable (Omsk & Siberia are land regions).`,
 }
 
 func YoungstownReduxBlank(phase godip.Phase) *state.State {
-	return state.New(YoungstownReduxGraph(), phase, classical.BackupRule, nil)
+	return state.New(YoungstownReduxGraph(), phase, classical.BackupRule, nil, nil)
 }
 
 func YoungstownReduxStart() (result *state.State, err error) {


### PR DESCRIPTION
I did not change the adjustment status calculation in the build order, since it's used to compute stuff for the adjudicator, and only applies to what's ALLOWED, not what's POSSIBLE.

The new function, private to the phase class and used only in the phase class, uses flags introduced to the validator to figure out where you are allowed to build, and computes how many builds are actually possible from there.