### PR TITLE
Update classical.go: change name of Tyrrhenian sea

### DIFF
--- a/variants/classical/classical.go
+++ b/variants/classical/classical.go
@@ -184,7 +184,7 @@ var provinceLongNames = map[godip.Province]string{
 	"bur":    "Burgundy",
 	"rum":    "Rumania",
 	"aeg":    "Aegean Sea",
-	"tys":    "Tyrhennian Sea",
+	"tys":    "Tyrrhenian Sea",
 	"mar":    "Marseilles",
 	"ruh":    "Ruhr",
 	"cly":    "Clyde",


### PR DESCRIPTION
line 187:      "tys":    "Tyrhennian Sea",   shall become "tys":    "Tyrrhenian Sea",