### PR TITLE
Implemented the missing rule "convoyed units can not break support against the convoy".

### DIFF
--- a/orders/convoy.go
+++ b/orders/convoy.go
@@ -262,6 +262,11 @@ type ConvoyPathFilter struct {
 	// If !ResolveConvoys, but VerifyConvoyOrderes, the participating fleets
 	// need to at least give the convoy order to be considered OK.
 	VerifyConvoyOrders bool
+	// If set, this province will not be considered.
+	// Used to find convoy paths not using a fleet attacked by someone supported
+	// by the convoy target province, which is used to check if a support
+	// is cut by the convoyed unit or not.
+	AvoidProvince *godip.Province
 }
 
 func (p ConvoyPathFilter) PathFilter(
@@ -276,6 +281,9 @@ func (p ConvoyPathFilter) PathFilter(
 		return true
 	}
 	if (superFlags[godip.Land] || !superFlags[godip.Sea]) && !superFlags[godip.Convoyable] {
+		return false
+	}
+	if p.AvoidProvince != nil && name.Super() == p.AvoidProvince.Super() {
 		return false
 	}
 	if u, _, ok := p.Validator.Unit(name); ok && u.Type == godip.Fleet && (p.OnlyNation == nil || u.Nation == *p.OnlyNation) {

--- a/orders/support.go
+++ b/orders/support.go
@@ -86,14 +86,14 @@ func (self *support) Adjudicate(r godip.Resolver) error {
 						supportedOrder.Targets()[1] == self.targets[2] { // to the correct destination
 						if MustConvoy(r, p) && len((ConvoyPathFinder{ // and the potential support breaker must convoy
 							ConvoyPathFilter: ConvoyPathFilter{
-								Validator:      r,
-								Source:         o.Targets()[0],
-								Destination:    o.Targets()[1],
-								ResolveConvoys: true,
-								AvoidProvince:  &self.targets[2],
+								Validator:          r,
+								Source:             o.Targets()[0],
+								Destination:        o.Targets()[1],
+								VerifyConvoyOrders: true,
+								AvoidProvince:      &self.targets[2],
 							},
 						}).Any()) == 0 { // and has no path other than the one we support attacking
-							return true // then this is not a valid support breaker
+							return false // then this is not a valid support breaker
 						}
 					}
 				}

--- a/variants/classical/classical_test.go
+++ b/variants/classical/classical_test.go
@@ -660,6 +660,22 @@ func TestCantBuildInCapturedHomeCenter(t *testing.T) {
 	tst.AssertNoUnit(t, judge, "mun")
 }
 
+func TestConvoySupportBreaking(t *testing.T) {
+	judge := Blank(NewPhase(1901, godip.Spring, godip.Movement))
+	judge.SetUnit("eng", godip.Unit{godip.Fleet, godip.England})
+	judge.SetUnit("lon", godip.Unit{godip.Army, godip.England})
+	judge.SetUnit("bel", godip.Unit{godip.Fleet, godip.France})
+	judge.SetUnit("nth", godip.Unit{godip.Fleet, godip.France})
+	judge.SetOrder("eng", orders.Convoy("eng", "lon", "bel"))
+	judge.SetOrder("lon", orders.Move("lon", "bel"))
+	judge.SetOrder("bel", orders.SupportMove("bel", "nth", "eng"))
+	judge.SetOrder("nth", orders.Move("nth", "eng"))
+	judge.Next()
+	if found := judge.Resolutions()["bel"]; found == nil {
+		t.Errorf("Wanted bel to fail, got %v", found)
+	}
+}
+
 func TestForceDisbandTracking(t *testing.T) {
 	judge := Blank(NewPhase(1901, godip.Spring, godip.Movement))
 	judge.SetUnit("pie", godip.Unit{godip.Army, godip.Italy})

--- a/variants/classical/classical_test.go
+++ b/variants/classical/classical_test.go
@@ -671,8 +671,8 @@ func TestConvoySupportBreaking(t *testing.T) {
 	judge.SetOrder("bel", orders.SupportMove("bel", "nth", "eng"))
 	judge.SetOrder("nth", orders.Move("nth", "eng"))
 	judge.Next()
-	if found := judge.Resolutions()["bel"]; found == nil {
-		t.Errorf("Wanted bel to fail, got %v", found)
+	if found, ok := judge.Resolutions()["eng"].(godip.ErrConvoyDislodged); !ok {
+		t.Errorf("Wanted eng to have ErrConvoyDislodged, got %v", found)
 	}
 }
 


### PR DESCRIPTION
See #132 and #128.

@tttppp, @TimothyJones, @RoganJosh, @jensforsgard PTAL

I think this is necessary.

No tests failed, so evidently the adjudicator has worked fine without knowing about this rule :O

I guess that's since the paradoxes the lack of the rule caused were resolved the same way as the rule resolved them.

I added a new test that fails if the code isn't there, anyway, so now we know this rule is implemented.